### PR TITLE
ask pip3 to install modules in user mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,12 +55,12 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
 echo "Installing for MacOSX"
-	pip3 install python-owasp-zap-v2.4
-	pip3 install beautifulsoup4
-	pip3 install lxml
-	pip3 install dicttoxml
-	pip3 install scipy
-	pip3 install paramiko
+	pip3 install --user python-owasp-zap-v2.4
+	pip3 install --user beautifulsoup4
+	pip3 install --user lxml
+	pip3 install --user dicttoxml
+	pip3 install --user scipy
+	pip3 install --user paramiko
 	python3 setup.py install
 elif [ "$(uname -s)" == "Linux" ]; then
 	sudo --validate # update sudo permissions, so we don't have to enter a passwd for the rest of the script
@@ -169,15 +169,15 @@ elif [ "$(uname -s)" == "Linux" ]; then
 		mkdir output
 	fi
 
-	do_command sudo pip3 install python-nmap
-	do_command sudo pip3 install python-owasp-zap-v2.4
-	do_command sudo pip3 install beautifulsoup4
-	do_command sudo pip3 install lxml
-	do_command sudo pip3 install dicttoxml
-	do_command sudo pip3 install progressbar2
-	do_command sudo pip3 install pathlib
-	do_command sudo pip3 install bcrypt
-	do_command sudo pip3 install pynacl
+	do_command sudo pip3 install --user python-nmap
+	do_command sudo pip3 install --user python-owasp-zap-v2.4
+	do_command sudo pip3 install --user beautifulsoup4
+	do_command sudo pip3 install --user lxml
+	do_command sudo pip3 install --user dicttoxml
+	do_command sudo pip3 install --user progressbar2
+	do_command sudo pip3 install --user pathlib
+	do_command sudo pip3 install --user bcrypt
+	do_command sudo pip3 install --user pynacl
 
 	# Now to write out a temp file which will indicate that we ran the install script 
 	touch ./var/adapt_installed


### PR DESCRIPTION
On some systems, pip3 doesn't have permission to access the Python system library directories, so the installation fails.